### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 on:
   - pull_request
   - push


### PR DESCRIPTION
Potential fix for [https://github.com/FrostFizzie/DFDevExplorer/security/code-scanning/1](https://github.com/FrostFizzie/DFDevExplorer/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, the only required permission is `contents: read`, which allows the workflow to read the repository contents. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
